### PR TITLE
Adds extra-libraries: kes_mmm_sumed25519_c to kes-mmm-sumed.cabal

### DIFF
--- a/kes-mmm-sumed25519-hs/kes-mmm-sumed.cabal
+++ b/kes-mmm-sumed25519-hs/kes-mmm-sumed.cabal
@@ -14,3 +14,4 @@ library
   hs-source-dirs: src
   build-depends: base >=4.7 && <5
   default-language: Haskell2010
+  extra-libraries: kes_mmm_sumed25519_c


### PR DESCRIPTION
To assist in picking up the dependency.