### PR TITLE
Update kes-mmm-sumed.cabal

### DIFF
--- a/kes-mmm-sumed25519-hs/kes-mmm-sumed.cabal
+++ b/kes-mmm-sumed25519-hs/kes-mmm-sumed.cabal
@@ -15,3 +15,11 @@ library
   build-depends: base >=4.7 && <5
   default-language: Haskell2010
   extra-libraries: kes_mmm_sumed25519_c
+  if os(windows)
+    -- these are needed for rust libs, ideally
+    -- ghc would provide these alongside with
+    -- the other libs it provided by default as
+    -- well.  Until this is fixed in ghc, we'll
+    -- need to provide them explicitly here.
+    extra-libraries: ws2_32 userenv
+


### PR DESCRIPTION
Add windows library dependencies. The rust library ends up depending on both. Until ghc provides them by default, we'll need to list them in the cabal file as well.